### PR TITLE
Remove pg u/p in dev/test envs

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -35,8 +35,6 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :swolen, Swolen.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "postgres",
-  password: "postgres",
   database: "swolen_dev",
   hostname: "localhost",
   pool_size: 10

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,8 +12,6 @@ config :logger, level: :warn
 # Configure your database
 config :swolen, Swolen.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "postgres",
-  password: "postgres",
   database: "swolen_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox


### PR DESCRIPTION
My environment doesn't have a postgres/postgres u/p. I don't think we should assume everyone does. We should be able to set PG_USER and PG_PASS in our environment if we wish to provide them.
